### PR TITLE
Fix Slider selecteurs

### DIFF
--- a/views/js/homeslider.js
+++ b/views/js/homeslider.js
@@ -26,16 +26,16 @@
 jQuery(document).ready(function ($) {
   var homesliderConfig = {
     speed: 500,            // Integer: Speed of the transition, in milliseconds
-    timeout: $('.homeslider-container').data('interval'), // Integer: Time between slide transitions, in milliseconds
+    timeout: $('.carousel').data('interval'), // Integer: Time between slide transitions, in milliseconds
     nav: true,             // Boolean: Show navigation, true or false
     random: false,          // Boolean: Randomize the order of the slides, true or false
-    pause: $('.homeslider-container').data('pause'), // Boolean: Pause on hover, true or false
+    pause: $('.carousel').data('pause'), // Boolean: Pause on hover, true or false
     maxwidth: "",           // Integer: Max-width of the slideshow, in pixels
     namespace: "homeslider",   // String: Change the default namespace used
     before: function(){},   // Function: Before callback
     after: function(){}     // Function: After callback
   };
 
-  $(".rslides").responsiveSlides(homesliderConfig);
+  $(".carousel").responsiveSlides(homesliderConfig);
 
 });


### PR DESCRIPTION
Correction nom des sélecteurs pour la librairie JS responsiveSlides. Utilisation des classes définies dans le fichier  classicblocks/views/templates/blocks/slides.tpl